### PR TITLE
Add inline dependency metadata to the script

### DIFF
--- a/dedupe_texts.py
+++ b/dedupe_texts.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#   "lxml",
+# ]
+# ///
+
 import argparse
 import os
 import sys


### PR DESCRIPTION
Dependencies can now be declared inline for a script, this lets tools like uv run the script without having to explicitly install the dependencies first.

https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata
https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies